### PR TITLE
Added additional include for CL_CHANNEL_XX macro definitions

### DIFF
--- a/include/hlslib/intel/OpenCL.h
+++ b/include/hlslib/intel/OpenCL.h
@@ -7,6 +7,8 @@
 #define HLSLIB_INTEL_OPENCL_H
 
 #include "CL/cl.hpp"
+#include "CL/cl_ext_intelfpga.h"
+
 #define HLSLIB_LEGACY_OPENCL
 
 #ifndef HLSLIB_INTEL


### PR DESCRIPTION
In version >19 Channel macros are in a different header.

There should be a compiler defined macro `INTELFPGA_CL`  but, of course, it doesn't work.

