### PR TITLE
hlslib as a subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,9 @@
 cmake_minimum_required(VERSION 3.0)
 project(hlslib)
 
-set(HLSLIB_ENABLE_TESTING CACHE BOOL ON
+set(HLSLIB_ENABLE_TESTING ON CACHE BOOL
     "Enable CTest when built as a standalone CMake project.")
-set(HLSLIB_BUILD_DOCUMENTATION CACHE BOOL ON
+set(HLSLIB_BUILD_DOCUMENTATION ON CACHE BOOL
     "Build Doxygen documentation when built as a standalone CMake project.")
 
 # Include custom Find<Module>.cmake scripts to enable searching for

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,10 @@
 cmake_minimum_required(VERSION 3.0)
 project(hlslib)
 
-set(HLSLIB_ENABLE_TESTING ON CACHE BOOL
-    "Enable CTest when built as a standalone CMake project.")
-set(HLSLIB_BUILD_DOCUMENTATION ON CACHE BOOL
-    "Build Doxygen documentation when built as a standalone CMake project.")
+option(HLSLIB_ENABLE_TESTING
+       "Enable CTest when built as a standalone CMake project." ON)
+option(HLSLIB_BUILD_DOCUMENTATION
+       "Build Doxygen documentation when built as a standalone CMake project." ON)
 
 # Include custom Find<Module>.cmake scripts to enable searching for
 # Vitis/SDx/SDAccel and Intel FPGA OpenCL.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,41 +3,70 @@
 cmake_minimum_required(VERSION 3.0)
 project(hlslib)
 
+set(HLSLIB_ENABLE_TESTING CACHE BOOL ON
+    "Enable CTest when built as a standalone CMake project.")
+set(HLSLIB_BUILD_DOCUMENTATION CACHE BOOL ON
+    "Build Doxygen documentation when built as a standalone CMake project.")
+
 # Include custom Find<Module>.cmake scripts to enable searching for
 # Vitis/SDx/SDAccel and Intel FPGA OpenCL.
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
-
-# Without this variable set, CMake will build tests when running install
-set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
-
-# Generate Doxygen if available
-find_package(Doxygen)
-if(Doxygen_FOUND)
-  configure_file(${CMAKE_SOURCE_DIR}/Doxyfile.in Doxyfile)
-  add_custom_target(doxygen ALL
-      COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile 
-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-endif()
-
-# hlslib target
-add_library(hlslib INTERFACE)
-target_include_directories(hlslib INTERFACE
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>)
-
-enable_testing()
 
 # Find Xilinx and Intel OpenCL software for enabling test targets 
 find_package(Threads)
 find_package(Vitis)
 find_package(IntelFPGAOpenCL)
 
-# Xilinx example setup and testing
-if(Vitis_FOUND AND Threads_FOUND)
-  add_subdirectory(xilinx_test)
+# hlslib target
+add_library(hlslib INTERFACE)
+target_include_directories(hlslib INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    ${Vitis_INCLUDE_DIRS}
+    ${IntelFPGAOpenCL_INCLUDE_DIRS})
+target_link_libraries(hlslib INTERFACE
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${Vitis_LIBRARIES}
+    ${IntelFPGAOpenCL_LIBRARIES})
+
+# Check if hlslib is being built standalone or as a subproject
+if(NOT CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  set(HLSLIB_IS_SUBPROJECT)
 endif()
-if(IntelFPGAOpenCL_FOUND AND Threads_FOUND)
-  add_subdirectory(intel_test)
+
+# Only build tests and documentation if hlslib is built standalone
+if(NOT HLSLIB_IS_SUBPROJECT)
+
+  if(HLSLIB_ENABLE_TESTING)
+
+    # Without this variable set, CMake will build tests when running install
+    set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
+
+    enable_testing()
+
+    # Xilinx example setup and testing
+    if(Vitis_FOUND AND Threads_FOUND)
+      add_subdirectory(xilinx_test)
+    endif()
+    if(IntelFPGAOpenCL_FOUND AND Threads_FOUND)
+      add_subdirectory(intel_test)
+    endif()
+
+  endif()
+
+  if(HLSLIB_BUILD_DOCUMENTATION)
+
+    # Generate Doxygen if available
+    find_package(Doxygen)
+    if(Doxygen_FOUND)
+      configure_file(${CMAKE_SOURCE_DIR}/Doxyfile.in Doxyfile)
+      add_custom_target(doxygen ALL
+          COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile 
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+    endif()
+
+  endif()
+
 endif()
 
 # Installation


### PR DESCRIPTION
To make it smoother to include CMake as a subproject:
- Disable testing and documentation if not built standalone.
- Expose the include directories and libraries found by `FindVitis.cmake` and `FindIntelOpenCL.cmake` in the `hlslib` target.
- Add switches to disable testing and documentation altogether.