### PR TITLE
Tight packing on hardware for DataPack

### DIFF
--- a/include/hlslib/xilinx/DataPack.h
+++ b/include/hlslib/xilinx/DataPack.h
@@ -42,7 +42,7 @@ template <int W, int I>
 class WidthCalculator<ap_fixed<W, I>> {
  public:
   #ifndef HLSLIB_SYNTHESIS
-  static constexpr int value = 8 * sizeof(ap_uint<W, I>);
+  static constexpr int value = 8 * sizeof(ap_fixed<W, I>);
   #else
   static constexpr int value = ap_fixed<W, I>::width;
   #endif

--- a/include/hlslib/xilinx/DataPack.h
+++ b/include/hlslib/xilinx/DataPack.h
@@ -22,7 +22,7 @@ namespace detail {
 /// Helper class to allow more efficient packing on the FPGA, where memory
 /// access is not restricted to byte-sized chunks.
 /// This class should be specialized for types with bit-widths that are not a
-/// multiple of a bite. For examples, see below specializations for common
+/// multiple of a byte. For examples, see below specializations for common
 /// Xilinx arbitrary bit-width types.
 template <typename T>
 struct TypeHandler {

--- a/include/hlslib/xilinx/DataPack.h
+++ b/include/hlslib/xilinx/DataPack.h
@@ -27,25 +27,31 @@ class WidthCalculator {
 };
 
 template<>
-template <int W>
-class WidthCalculator<ap_uint<W>> {
+template <int _AP_W>
+class WidthCalculator<ap_int<_AP_W>> {
  public:
-  #ifndef HLSLIB_SYNTHESIS
-  static constexpr int value = 8 * sizeof(ap_uint<W>);
-  #else
-  static constexpr int value = W;
-  #endif
+  static constexpr int value = _AP_W;
 };
 
 template<>
-template <int W, int I>
-class WidthCalculator<ap_fixed<W, I>> {
+template <int _AP_W>
+class WidthCalculator<ap_uint<_AP_W>> {
  public:
-  #ifndef HLSLIB_SYNTHESIS
-  static constexpr int value = 8 * sizeof(ap_fixed<W, I>);
-  #else
-  static constexpr int value = W;
-  #endif
+  static constexpr int value = _AP_W;
+};
+
+template<>
+template <int _AP_W, int _AP_I, ap_q_mode _AP_Q, ap_o_mode _AP_O, int _AP_N>
+class WidthCalculator<ap_fixed<_AP_W, _AP_I, _AP_Q, _AP_O, _AP_N>> {
+ public:
+  static constexpr int value = _AP_W;
+};
+
+template<>
+template <int _AP_W, int _AP_I, ap_q_mode _AP_Q, ap_o_mode _AP_O, int _AP_N>
+class WidthCalculator<ap_ufixed<_AP_W, _AP_I, _AP_Q, _AP_O, _AP_N>> {
+ public:
+  static constexpr int value = _AP_W;
 };
 
 

--- a/include/hlslib/xilinx/DataPack.h
+++ b/include/hlslib/xilinx/DataPack.h
@@ -28,11 +28,11 @@ template <typename T>
 struct TypeHandler {
   static constexpr int width = 8 * sizeof(T);
 
-  static T from_range(ap_uint<width> range) {
+  static T from_range(ap_uint<width> const &range) {
     return *reinterpret_cast<T const *>(&range);
   }
 
-  static ap_uint<width> to_range(T value) {
+  static ap_uint<width> to_range(T const &value) {
     return *reinterpret_cast<ap_uint<width> const *>(&value);
   }
 };
@@ -41,26 +41,26 @@ template <int _AP_W>
 struct TypeHandler<ap_int<_AP_W>> {
   static constexpr int width = _AP_W;
 
-  static ap_int<_AP_W> from_range(ap_uint<width> range) {
+  static ap_int<_AP_W> from_range(ap_uint<width> const &range) {
     ap_int<_AP_W> out;
     out.range() = range;
     return out;
   }
 
-  static ap_uint<width> to_range(ap_int<_AP_W> value) { return value.range(); }
+  static ap_uint<width> to_range(ap_int<_AP_W> const &value) { return value.range(); }
 };
 
 template <int _AP_W>
 struct TypeHandler<ap_uint<_AP_W>> {
   static constexpr int width = _AP_W;
 
-  static ap_uint<_AP_W> from_range(ap_uint<width> range) {
+  static ap_uint<_AP_W> from_range(ap_uint<width> const &range) {
     ap_uint<_AP_W> out;
     out.range() = range;
     return out;
   }
 
-  static ap_uint<width> to_range(ap_uint<_AP_W> value) { return value.range(); }
+  static ap_uint<width> to_range(ap_uint<_AP_W> const &value) { return value.range(); }
 };
 
 template <int _AP_W, int _AP_I, ap_q_mode _AP_Q, ap_o_mode _AP_O, int _AP_N>
@@ -68,7 +68,7 @@ struct TypeHandler<ap_fixed<_AP_W, _AP_I, _AP_Q, _AP_O, _AP_N>> {
   static constexpr int width = _AP_W;
 
   static ap_fixed<_AP_W, _AP_I, _AP_Q, _AP_O, _AP_N> from_range(
-    ap_uint<width> range
+    ap_uint<width> const &range
   ) {
     ap_fixed<_AP_W, _AP_I, _AP_Q, _AP_O, _AP_N> out;
     out.range() = range;
@@ -76,7 +76,7 @@ struct TypeHandler<ap_fixed<_AP_W, _AP_I, _AP_Q, _AP_O, _AP_N>> {
   }
 
   static ap_uint<width> to_range(
-    ap_fixed<_AP_W, _AP_I, _AP_Q, _AP_O, _AP_N> value
+    ap_fixed<_AP_W, _AP_I, _AP_Q, _AP_O, _AP_N> const &value
   ) {
     return value.range().to_ap_int_base();
   }
@@ -87,7 +87,7 @@ struct TypeHandler<ap_ufixed<_AP_W, _AP_I, _AP_Q, _AP_O, _AP_N>> {
   static constexpr int width = _AP_W;
 
   static ap_ufixed<_AP_W, _AP_I, _AP_Q, _AP_O, _AP_N> from_range(
-    ap_uint<width> range
+    ap_uint<width> const &range
   ) {
     ap_ufixed<_AP_W, _AP_I, _AP_Q, _AP_O, _AP_N> out;
     out.range() = range;
@@ -95,7 +95,7 @@ struct TypeHandler<ap_ufixed<_AP_W, _AP_I, _AP_Q, _AP_O, _AP_N>> {
   }
 
   static ap_uint<width> to_range(
-    ap_ufixed<_AP_W, _AP_I, _AP_Q, _AP_O, _AP_N> value
+    ap_ufixed<_AP_W, _AP_I, _AP_Q, _AP_O, _AP_N> const &value
   ) {
     return value.range().to_ap_int_base();
   }

--- a/include/hlslib/xilinx/DataPack.h
+++ b/include/hlslib/xilinx/DataPack.h
@@ -44,7 +44,7 @@ class WidthCalculator<ap_fixed<W, I>> {
   #ifndef HLSLIB_SYNTHESIS
   static constexpr int value = 8 * sizeof(ap_fixed<W, I>);
   #else
-  static constexpr int value = ap_fixed<W, I>::width;
+  static constexpr int value = W;
   #endif
 };
 

--- a/include/hlslib/xilinx/DataPack.h
+++ b/include/hlslib/xilinx/DataPack.h
@@ -19,7 +19,9 @@ class DataPackProxy; // Forward declaration
 
 /// Helper class to allow more efficient packing on the FPGA, where memory
 /// access is not restricted to byte-sized chunks.
-/// Specializations of this class for
+/// This class should be specialized for types with bit-widths that are not a
+/// multiple of a bite. For examples, see below specializations for common
+/// Xilinx arbitrary bit-width types.
 template <typename T>
 class TypeHandler {
  public:

--- a/xilinx_test/test/TestDataPack.cpp
+++ b/xilinx_test/test/TestDataPack.cpp
@@ -48,64 +48,64 @@ TEMPLATE_TEST_CASE(
   }
 
   SECTION("Assignment copy operator") {
-    DataPack lhs(0);
+    DataPack lhs((TestType)0);
     for (int i = 0; i < kWidth; ++i) {
-      REQUIRE((TestType)lhs[i] == 0);
+      REQUIRE(lhs.Get(i) == 0);
     }
     DataPack rhs(kFillVal);
     lhs = rhs;
     for (int i = 0; i < kWidth; ++i) {
-      REQUIRE((TestType)lhs[i] == kFillVal);
+      REQUIRE(lhs.Get(i) == kFillVal);
     }
   }
 
   SECTION("Assignment move operator") {
-    DataPack lhs(0);
+    DataPack lhs((TestType)0);
     for (int i = 0; i < kWidth; ++i) {
-      REQUIRE((TestType)lhs[i] == 0);
+      REQUIRE(lhs.Get(i) == 0);
     }
     DataPack rhs(kFillVal);
     lhs = std::move(rhs);
     for (int i = 0; i < kWidth; ++i) {
-      REQUIRE((TestType)lhs[i] == kFillVal);
+      REQUIRE(lhs.Get(i) == kFillVal);
     }
   }
 
   SECTION("Index-wise assignment") {
-    DataPack lhs(0);
+    DataPack lhs((TestType)0);
     DataPack rhs(kFillVal);
     for (int i = 0; i < kWidth; ++i) {
-      REQUIRE((TestType)lhs[i] == 0);
+      REQUIRE(lhs.Get(i) == 0);
     }
     for (int i = 0; i < kWidth; ++i) {
       lhs[i] = rhs[i];
     }
     for (int i = 0; i < kWidth; ++i) {
-      REQUIRE((TestType)lhs[i] == kFillVal);
+      REQUIRE(lhs.Get(i) == kFillVal);
     }
   }
 
   SECTION("Shift operation") {
     DataPack first(kFillVal);
-    DataPack second(0);
+    DataPack second((TestType)0);
     first.template ShiftTo<0, kWidth/2, kWidth/2>(second);
     for (int i = 0; i < kWidth/2; ++i) {
-      REQUIRE((TestType)second[i] == 0);
+      REQUIRE(second.Get(i) == 0);
     }
     for (int i = kWidth/2; i < kWidth; ++i) {
-      REQUIRE((TestType)second[i] == kFillVal);
+      REQUIRE(second.Get(i) == kFillVal);
     }
   }
 
   SECTION("Pack and unpack") {
-    DataPack pack(0);
+    DataPack pack((TestType)0);
     TestType arr0[kWidth];
     TestType arr1[kWidth];
     std::fill(arr0, arr0 + kWidth, kFillVal);
     std::fill(arr1, arr1 + kWidth, 0);
     pack.Pack(arr0);
     for (int i = 0; i < kWidth; ++i) {
-      REQUIRE((TestType)pack[i] == arr0[i]);
+      REQUIRE(pack.Get(i) == arr0[i]);
     }
     pack.Unpack(arr1);
     for (int i = 0; i < kWidth; ++i) {
@@ -115,7 +115,7 @@ TEMPLATE_TEST_CASE(
     std::fill(arr1, arr1 + kWidth, 0);
     pack << arr0;
     for (int i = 0; i < kWidth; ++i) {
-      REQUIRE((TestType)pack[i] == arr0[i]);
+      REQUIRE(pack.Get(i) == arr0[i]);
     }
     pack >> arr1;
     for (int i = 0; i < kWidth; ++i) {

--- a/xilinx_test/test/TestDataPack.cpp
+++ b/xilinx_test/test/TestDataPack.cpp
@@ -4,12 +4,16 @@
 #include "hlslib/xilinx/DataPack.h"
 #include "catch.hpp"
 
-using Test_t = int;
-constexpr int kWidth = 4;
-constexpr int kFillVal = 5;
-using DataPack = hlslib::DataPack<Test_t, kWidth>;
+#include "ap_fixed.h"
+#include "ap_int.h"
 
-TEST_CASE("DataPack", "[DataPack]") {
+constexpr int kWidth = 4;
+
+TEMPLATE_TEST_CASE(
+    "DataPack", "[DataPack][template]",
+    int, ap_int<3>, ap_uint<33>, (ap_fixed<9, 4>), (ap_ufixed<19, 5>)) {
+  const TestType kFillVal = 5;
+  using DataPack = hlslib::DataPack<TestType, kWidth>;
 
   SECTION("Fill constructor") {
     const DataPack pack(kFillVal);
@@ -35,7 +39,7 @@ TEST_CASE("DataPack", "[DataPack]") {
   }
 
   SECTION("Array constructor") {
-    Test_t arr[kWidth];
+    TestType arr[kWidth];
     std::fill(arr, arr + kWidth, kFillVal);
     const DataPack pack(arr);
     for (int i = 0; i < kWidth; ++i) {
@@ -46,24 +50,24 @@ TEST_CASE("DataPack", "[DataPack]") {
   SECTION("Assignment copy operator") {
     DataPack lhs(0);
     for (int i = 0; i < kWidth; ++i) {
-      REQUIRE(lhs[i] == 0);
+      REQUIRE((TestType)lhs[i] == 0);
     }
     DataPack rhs(kFillVal);
     lhs = rhs;
     for (int i = 0; i < kWidth; ++i) {
-      REQUIRE(lhs[i] == kFillVal);
+      REQUIRE((TestType)lhs[i] == kFillVal);
     }
   }
 
   SECTION("Assignment move operator") {
     DataPack lhs(0);
     for (int i = 0; i < kWidth; ++i) {
-      REQUIRE(lhs[i] == 0);
+      REQUIRE((TestType)lhs[i] == 0);
     }
     DataPack rhs(kFillVal);
     lhs = std::move(rhs);
     for (int i = 0; i < kWidth; ++i) {
-      REQUIRE(lhs[i] == kFillVal);
+      REQUIRE((TestType)lhs[i] == kFillVal);
     }
   }
 
@@ -71,37 +75,37 @@ TEST_CASE("DataPack", "[DataPack]") {
     DataPack lhs(0);
     DataPack rhs(kFillVal);
     for (int i = 0; i < kWidth; ++i) {
-      REQUIRE(lhs[i] == 0);
+      REQUIRE((TestType)lhs[i] == 0);
     }
     for (int i = 0; i < kWidth; ++i) {
       lhs[i] = rhs[i];
     }
     for (int i = 0; i < kWidth; ++i) {
-      REQUIRE(lhs[i] == kFillVal);
+      REQUIRE((TestType)lhs[i] == kFillVal);
     }
   }
 
   SECTION("Shift operation") {
     DataPack first(kFillVal);
     DataPack second(0);
-    first.ShiftTo<0, kWidth/2, kWidth/2>(second);
+    first.template ShiftTo<0, kWidth/2, kWidth/2>(second);
     for (int i = 0; i < kWidth/2; ++i) {
-      REQUIRE(second[i] == 0);
+      REQUIRE((TestType)second[i] == 0);
     }
     for (int i = kWidth/2; i < kWidth; ++i) {
-      REQUIRE(second[i] == kFillVal);
+      REQUIRE((TestType)second[i] == kFillVal);
     }
   }
 
   SECTION("Pack and unpack") {
     DataPack pack(0);
-    Test_t arr0[kWidth];
-    Test_t arr1[kWidth];
+    TestType arr0[kWidth];
+    TestType arr1[kWidth];
     std::fill(arr0, arr0 + kWidth, kFillVal);
     std::fill(arr1, arr1 + kWidth, 0);
     pack.Pack(arr0);
     for (int i = 0; i < kWidth; ++i) {
-      REQUIRE(pack[i] == arr0[i]);
+      REQUIRE((TestType)pack[i] == arr0[i]);
     }
     pack.Unpack(arr1);
     for (int i = 0; i < kWidth; ++i) {
@@ -111,7 +115,7 @@ TEST_CASE("DataPack", "[DataPack]") {
     std::fill(arr1, arr1 + kWidth, 0);
     pack << arr0;
     for (int i = 0; i < kWidth; ++i) {
-      REQUIRE(pack[i] == arr0[i]);
+      REQUIRE((TestType)pack[i] == arr0[i]);
     }
     pack >> arr1;
     for (int i = 0; i < kWidth; ++i) {

--- a/xilinx_test/test/TestDataPack.cpp
+++ b/xilinx_test/test/TestDataPack.cpp
@@ -48,7 +48,7 @@ TEMPLATE_TEST_CASE(
   }
 
   SECTION("Assignment copy operator") {
-    DataPack lhs((TestType)0);
+    DataPack lhs(TestType(0));
     for (int i = 0; i < kWidth; ++i) {
       REQUIRE(lhs.Get(i) == 0);
     }
@@ -60,7 +60,7 @@ TEMPLATE_TEST_CASE(
   }
 
   SECTION("Assignment move operator") {
-    DataPack lhs((TestType)0);
+    DataPack lhs(TestType(0));
     for (int i = 0; i < kWidth; ++i) {
       REQUIRE(lhs.Get(i) == 0);
     }
@@ -72,7 +72,7 @@ TEMPLATE_TEST_CASE(
   }
 
   SECTION("Index-wise assignment") {
-    DataPack lhs((TestType)0);
+    DataPack lhs(TestType(0));
     DataPack rhs(kFillVal);
     for (int i = 0; i < kWidth; ++i) {
       REQUIRE(lhs.Get(i) == 0);
@@ -87,7 +87,7 @@ TEMPLATE_TEST_CASE(
 
   SECTION("Shift operation") {
     DataPack first(kFillVal);
-    DataPack second((TestType)0);
+    DataPack second(TestType(0));
     first.template ShiftTo<0, kWidth/2, kWidth/2>(second);
     for (int i = 0; i < kWidth/2; ++i) {
       REQUIRE(second.Get(i) == 0);
@@ -98,7 +98,7 @@ TEMPLATE_TEST_CASE(
   }
 
   SECTION("Pack and unpack") {
-    DataPack pack((TestType)0);
+    DataPack pack(TestType(0));
     TestType arr0[kWidth];
     TestType arr1[kWidth];
     std::fill(arr0, arr0 + kWidth, kFillVal);

--- a/xilinx_test/test/TestDataPack.cpp
+++ b/xilinx_test/test/TestDataPack.cpp
@@ -11,7 +11,7 @@ constexpr int kWidth = 4;
 
 TEMPLATE_TEST_CASE(
     "DataPack", "[DataPack][template]",
-    int, ap_int<3>, ap_uint<33>, (ap_fixed<9, 4>), (ap_ufixed<19, 5>)) {
+    int, ap_int<5>, ap_uint<33>, (ap_fixed<9, 4>), (ap_ufixed<19, 5>)) {
   const TestType kFillVal = 5;
   using DataPack = hlslib::DataPack<TestType, kWidth>;
 


### PR DESCRIPTION
This pull request attempts to solve #43 by implementing tight packing for the DataPack class.
Mainly this is done through a small proxy template class that can easily be specialized for any datatype who's bit width is not a multiple of 8.

I also added a few sample specializations for the `ap_uint` and the `ap_fixed` types, but they are not ideal yet by any means.

One problem that this may introduce is that the code will not be equivalent between CPU and FPGA, and thus testing is difficult (impossible?) without actually running tests on an FPGA.