### PR TITLE
Simulate Waiting for OpenCL Events

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Google
+IndentWidth: 2
+AllowShortFunctionsOnASingleLine: None

--- a/include/hlslib/common/OpenCL.h
+++ b/include/hlslib/common/OpenCL.h
@@ -59,15 +59,19 @@ using Event = cl::Event;
 class Event {
  public:
   Event(std::function<void(void)> const &f) {
-    future_ = std::async(std::launch::async, f);
+    future_ = std::async(std::launch::async, f).share();
   }
+
+  // Because we use a shared_future, we can copy this object
+  Event(Event &&) = default;
+  Event(Event const &) = default;
 
   void wait() const {
     return future_.wait();
   }
 
  private:
-  std::future<void> future_;
+  std::shared_future<void> future_;
 };
 #endif
 

--- a/include/hlslib/common/OpenCL.h
+++ b/include/hlslib/common/OpenCL.h
@@ -1499,10 +1499,13 @@ class Kernel {
     }
     return Event(event);
 #else
-    for (; eventsBegin != eventsEnd; ++eventsBegin) {
-      eventsBegin->wait();
-    }
-    return Event(hostFunction_);  // Simulate by calling host function
+
+    return Event([this, &eventsBegin, &eventsEnd]() {
+      for (; eventsBegin != eventsEnd; ++eventsBegin) {
+        eventsBegin->wait();
+      }
+      hostFunction_();
+    });  // Simulate by calling host function
 #endif
   }
 

--- a/include/hlslib/common/OpenCL.h
+++ b/include/hlslib/common/OpenCL.h
@@ -1624,7 +1624,9 @@ Kernel Program::MakeKernel(F &&hostFunction, std::string const &kernelName,
                 std::forward<Ts>(args)...);
 }
 
-cl_int WaitForEvents(std::vector<Event> const &events) {
+/// Analogous to cl::waitForEvents, but compatible with the hlslib wrapper so it
+/// works across simulation and hardware environments.
+inline cl_int WaitForEvents(std::vector<Event> const &events) {
 #ifdef HLSLIB_SIMULATE_OPENCL
   for (auto &e : events) {
     e.wait();

--- a/include/hlslib/common/OpenCL.h
+++ b/include/hlslib/common/OpenCL.h
@@ -1500,9 +1500,9 @@ class Kernel {
     return Event(event);
 #else
 
-    return Event([this, &eventsBegin, &eventsEnd]() {
-      for (; eventsBegin != eventsEnd; ++eventsBegin) {
-        eventsBegin->wait();
+    return Event([this, eventsBegin, eventsEnd]() {
+      for (auto i = eventsBegin; i != eventsEnd; ++i) {
+        i->wait();
       }
       hostFunction_();
     });  // Simulate by calling host function

--- a/include/hlslib/xilinx/OpenCL.h
+++ b/include/hlslib/xilinx/OpenCL.h
@@ -30,7 +30,7 @@ DSAs. Therefore for Xilinx these flags are now initialized and stored as part of
 the Context class
 */
 class DDRBankFlags {
-public:
+ public:
   DDRBankFlags(const std::string &device_name) {
     if (device_name.find("xilinx_u280") != std::string::npos) {
       memory_bank_0_ = XCL_MEM_TOPOLOGY | 32;
@@ -42,17 +42,27 @@ public:
     }
   }
 
-  DDRBankFlags() { DefaultAssignment(); }
+  DDRBankFlags() {
+    DefaultAssignment();
+  }
 
-  inline int memory_bank_0() const { return memory_bank_0_; }
+  inline int memory_bank_0() const {
+    return memory_bank_0_;
+  }
 
-  inline int memory_bank_1() const { return memory_bank_1_; }
+  inline int memory_bank_1() const {
+    return memory_bank_1_;
+  }
 
-  inline int memory_bank_2() const { return memory_bank_2_; }
+  inline int memory_bank_2() const {
+    return memory_bank_2_;
+  }
 
-  inline int memory_bank_3() const { return memory_bank_3_; }
+  inline int memory_bank_3() const {
+    return memory_bank_3_;
+  }
 
-private:
+ private:
   void DefaultAssignment() {
     memory_bank_0_ = XCL_MEM_DDR_BANK0;
     memory_bank_1_ = XCL_MEM_DDR_BANK1;
@@ -66,16 +76,17 @@ private:
   int memory_bank_3_;
 };
 
-//See: Documentation: https://www.xilinx.com/support/documentation/sw_manuals/xilinx2020_2/ug1393-vitis-application-acceleration.pdf
-//HBM Examples: https://github.com/Xilinx/Vitis_Accel_Examples/tree/master/host
+// See: Documentation:
+// https://www.xilinx.com/support/documentation/sw_manuals/xilinx2020_2/ug1393-vitis-application-acceleration.pdf
+// HBM Examples: https://github.com/Xilinx/Vitis_Accel_Examples/tree/master/host
 constexpr auto kHBMStorageMagicNumber = XCL_MEM_TOPOLOGY;
 using ExtendedMemoryPointer = cl_mem_ext_ptr_t;
 
 constexpr cl_command_queue_properties kCommandQueueFlags =
     CL_QUEUE_PROFILING_ENABLE | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE;
 
-} // End namespace ocl
+}  // End namespace ocl
 
-} // End namespace hlslib
+}  // End namespace hlslib
 
 #include "../common/OpenCL.h"

--- a/intel_test/include/Jacobi2D.h
+++ b/intel_test/include/Jacobi2D.h
@@ -3,9 +3,9 @@
 
 #pragma OPENCL EXTENSION cl_intel_channels : enable
 
-#define H 512
-#define W 512
-#define T 4
+#define COLS 512
+#define ROWS 512
+#define TIMESTEPS 4
 #define DTYPE float
 
 #endif

--- a/intel_test/kernels/Jacobi2D.cl
+++ b/intel_test/kernels/Jacobi2D.cl
@@ -1,14 +1,14 @@
 #include "Jacobi2D.h"
 
-channel float read_stream __attribute__((depth(W)));
-channel float write_stream __attribute__((depth(W)));
+channel float read_stream __attribute__((depth(COLS)));
+channel float write_stream __attribute__((depth(COLS)));
 
 __kernel void Read(__global volatile const float memory[]) {
-  for (int t = 0; t < T; ++t) {
-    int offset = (t % 2 == 0) ? 0 : H * W;
-    for (int i = 0; i < H; ++i) {
-      for (int j = 0; j < W; ++j) {
-        DTYPE read = memory[offset + i*W + j];
+  for (int t = 0; t < TIMESTEPS; ++t) {
+    int offset = (t % 2 == 0) ? 0 : ROWS * COLS;
+    for (int i = 0; i < ROWS; ++i) {
+      for (int j = 0; j < COLS; ++j) {
+        DTYPE read = memory[offset + i * COLS + j];
         write_channel_intel(read_stream, read);
       }
     }
@@ -16,20 +16,20 @@ __kernel void Read(__global volatile const float memory[]) {
 }
 
 __kernel void Jacobi2D() {
-  for (int t = 0; t < T; ++t) {
-    DTYPE buffer[2*W + 1];
-    for (int i = 0; i < H; ++i) {
-      for (int j = 0; j < W; ++j) {
+  for (int t = 0; t < TIMESTEPS; ++t) {
+    DTYPE buffer[2 * COLS + 1];
+    for (int i = 0; i < ROWS; ++i) {
+      for (int j = 0; j < COLS; ++j) {
         // Shift buffer
         #pragma unroll
-        for (int b = 0; b < 2*W; ++b) {
+        for (int b = 0; b < 2 * COLS; ++b) {
           buffer[b] = buffer[b + 1];
         }
         // Read into front
-        buffer[2*W] = read_channel_intel(read_stream);
-        if (i >= 2 && j >= 1 && j < W - 1) {
-          DTYPE res = 0.25 * (buffer[2*W] + buffer[W - 1] +
-                              buffer[W + 1] + buffer[0]);
+        buffer[2 * COLS] = read_channel_intel(read_stream);
+        if (i >= 2 && j >= 1 && j < COLS - 1) {
+          DTYPE res = 0.25 * (buffer[2 * COLS] + buffer[COLS - 1] +
+                              buffer[COLS + 1] + buffer[0]);
           write_channel_intel(write_stream, res);
         }
       }
@@ -38,12 +38,12 @@ __kernel void Jacobi2D() {
 }
 
 __kernel void Write(__global volatile float memory[]) {
-  for (int t = 0; t < T; ++t) {
-    int offset = (t % 2 == 0) ? H * W : 0;
-    for (int i = 1; i < H - 1; ++i) {
-      for (int j = 1; j < W - 1; ++j) {
+  for (int t = 0; t < TIMESTEPS; ++t) {
+    int offset = (t % 2 == 0) ? ROWS * COLS : 0;
+    for (int i = 1; i < ROWS - 1; ++i) {
+      for (int j = 1; j < COLS - 1; ++j) {
         DTYPE read = read_channel_intel(write_stream);
-        memory[offset + i*W + j] = read;
+        memory[offset + i * COLS + j] = read;
       }
     }
   }


### PR DESCRIPTION
The behavior when running multiple kernels waiting on events between them was wrong in simulation mode.

This is now emulated using `std::shared_future` on the function simulating the kernel that can be passed between kernel invocations. 