### PR TITLE
Add support for free-running functions in simulation 

### DIFF
--- a/include/hlslib/xilinx/Simulation.h
+++ b/include/hlslib/xilinx/Simulation.h
@@ -9,7 +9,6 @@
 #include <queue>
 #include <thread>
 #include <vector>
-#include <functional>
 // #include "hlslib/Stream.h"
 #endif
 

--- a/include/hlslib/xilinx/Simulation.h
+++ b/include/hlslib/xilinx/Simulation.h
@@ -10,7 +10,6 @@
 #include <thread>
 #include <vector>
 #include <functional>
-#include <iostream>
 // #include "hlslib/Stream.h"
 #endif
 


### PR DESCRIPTION
Xilinx HLS IP can be free-running (they self-restart) for example by setting control mode to `ap_ctrl_none` in Vivado/Vitis HLS. This is a relatively common design pattern.

I've added an additional simulation macro, `HLSLIB_FREERUNNING_FUNCTION`, which wraps the function in a `while(1)` before launching the thread, such that the function executes repeatedly, emulating the expected real-world behaviour. This works, with a minimal application example such as this:

```
#include "Stream.h"
#include "Simulation.h"
#include <iostream>
#include <chrono>
#include <thread>

using namespace std;
using namespace hlslib;

void f1(Stream<int> &s, int val){
    cout << "Putting stuff in stream" << endl;
    s.Push(val);
}

void f2(Stream<int> &in, Stream<int> &out){
    cout << "Copying stuff in stream" << endl;
    out.Push(in.Pop());
}

void f3(Stream<int> &s){
    cout << "Getting stuff from stream" << endl;
    int val = s.Pop();
    cout << val << endl;
}

int main(){
    Stream<int> s0, s1;

    // Dataflow functions running in parallel
    HLSLIB_DATAFLOW_INIT();
    HLSLIB_DATAFLOW_FUNCTION(f1, s0, 2);
    HLSLIB_FREERUNNING_FUNCTION(f2, s0, s1);
    HLSLIB_DATAFLOW_FUNCTION(f3, s1);
    HLSLIB_DATAFLOW_FINALIZE();
}
```

There is a fundamental problem to this approach though which is that we can't expect free-running functions to ever finish. Even if I were to provide a mechanism to interrupt the restarting loop, there isn't any guarantee that the function had not been already restarted by the time the interrupt signal comes, in which case it may be blocking on a stream read. Therefore, I've chosen the simplest approach which is to join only dataflow function threads, which are kept in a separate queue from free-running function threads, which will be killed on program exit. 

