### PR TITLE
Explicit packing of Command/Status

### DIFF
--- a/include/hlslib/xilinx/Axi.h
+++ b/include/hlslib/xilinx/Axi.h
@@ -43,6 +43,20 @@ struct Command {
   Command(decltype(address) const &_address, decltype(length) const &_length)
       : length(_length), address(_address) {}
   Command() : length(0), address(0) {}
+  Command(ap_uint<addressWidth+bttWidth+17> const &cmd)
+      : length(cmd(22,0)), type(cmd(23,23)), dsa(cmd(29,24)), eof(cmd(30,30)), drr(cmd(31,31)), address(cmd(95,32)), tag(cmd(99,96)) {}
+  operator ap_uint<addressWidth+bttWidth+17>(){
+    ap_uint<addressWidth+bttWidth+17> ret;
+    ret(22,0) = length;
+    ret(23,23) = type;
+    ret(29,24) = dsa;
+    ret(30,30) = eof;
+    ret(31,31) = drr;
+    ret(95,32) = address;
+    ret(99,96) = tag;
+    ret(103,100) = 0;
+    return ret;
+  }
 };
 
 /// Implements the status bus interface for the DataMover IP
@@ -57,6 +71,20 @@ struct Status { // 8 bits
 
 	Status(bool _okay) : okay(_okay) {}  
   Status() : okay(true) {}
+  Status(ap_uint<32> sts)
+     : tag(sts(3,0)), internalError(sts(4,4)), decodeError(sts(5,5)), slaveError(sts(6,6)), 
+        okay(sts(7,7)), bytesReceived(sts(30,8)), endOfPacket(sts(31,31)) {}
+  operator ap_uint<32>(){
+    ap_uint<32> ret;
+    ret(3,0) = tag;
+    ret(4,4) = internalError;
+    ret(5,5) = decodeError;
+    ret(5,5) = slaveError;
+    ret(7,7) = okay;
+    ret(30,8) = bytesReceived;
+    ret(31,31) = endOfPacket;
+    return ret;
+  }
 };
 
 } // End namespace axi 

--- a/include/hlslib/xilinx/Axi.h
+++ b/include/hlslib/xilinx/Axi.h
@@ -47,14 +47,14 @@ struct Command {
       : length(cmd(22,0)), type(cmd(23,23)), dsa(cmd(29,24)), eof(cmd(30,30)), drr(cmd(31,31)), address(cmd(95,32)), tag(cmd(99,96)) {}
   operator ap_uint<addressWidth+bttWidth+17>(){
     ap_uint<addressWidth+bttWidth+17> ret;
-    ret(22,0) = length;
-    ret(23,23) = type;
-    ret(29,24) = dsa;
-    ret(30,30) = eof;
-    ret(31,31) = drr;
-    ret(95,32) = address;
-    ret(99,96) = tag;
-    ret(103,100) = 0;
+    ret(bttWidth-1,0) = length;
+    ret(bttWidth,bttWidth) = type;
+    ret(bttWidth+6,bttWidth+1) = dsa;
+    ret(bttWidth+7,bttWidth+7) = eof;
+    ret(bttWidth+8,bttWidth+8) = drr;
+    ret(addressWidth+bttWidth+8,bttWidth+9) = address;
+    ret(addressWidth+bttWidth+12,addressWidth+bttWidth+9) = tag;
+    ret(addressWidth+bttWidth+16,addressWidth+bttWidth+13) = 0;
     return ret;
   }
 };
@@ -68,6 +68,8 @@ struct Status { // 8 bits
   ap_uint<1> decodeError{0};
   ap_uint<1> slaveError{0};
   ap_uint<1> okay;
+  ap_uint<23> bytesReceived{0};
+  ap_uint<1> endOfPacket{0};
 
 	Status(bool _okay) : okay(_okay) {}  
   Status() : okay(true) {}

--- a/include/hlslib/xilinx/Axi.h
+++ b/include/hlslib/xilinx/Axi.h
@@ -81,7 +81,7 @@ struct Status { // 8 bits
     ret(3,0) = tag;
     ret(4,4) = internalError;
     ret(5,5) = decodeError;
-    ret(5,5) = slaveError;
+    ret(6,6) = slaveError;
     ret(7,7) = okay;
     ret(30,8) = bytesReceived;
     ret(31,31) = endOfPacket;


### PR DESCRIPTION
This PR has two changes:

- added bytesReceived and endOfPacket fields to hlslib::axi::Status which are set by datamovers when Indeterminate BTT mode is set
- added constructors and casting functions enabling easy explicit conversion of Command/Status to/from ap_uint. There appears to be a problem with tight packing of structure fields on stream interfaces in the latest Vitis HLS, therefore this change makes it easier to do manual packing.