### PR TITLE
Add read_nb compability function to xilinx/Stream.h

### DIFF
--- a/include/hlslib/xilinx/Stream.h
+++ b/include/hlslib/xilinx/Stream.h
@@ -170,6 +170,12 @@ class Stream<T, 0, Storage::Unspecified> {
   }
 
   /// Compatibility with hls::stream interface.
+  bool read_nb(T &out) {
+    #pragma HLS INLINE
+    return ReadNonBlocking(out);
+  }
+
+  /// Compatibility with hls::stream interface.
   void write(T const &val) {
     #pragma HLS INLINE
     WriteBlocking(val);


### PR DESCRIPTION
Currently i am using only the xilinx/Stream.h of hlslib and not hlslib itself, therefore this compability function is very handy.

It is tested in the sense, that i am using it in software emulation now, but i am not sure if there can or should be done more, so i am opening this PR already.

Best Regards

Gerrit